### PR TITLE
halfhandshaker.sh: Error fix, code optimizations

### DIFF
--- a/halfhandshaker.sh
+++ b/halfhandshaker.sh
@@ -23,26 +23,6 @@ s1="[$(tput setaf 2)+$(tput sgr0)]"
 s2="[$(tput setaf 4)+$(tput sgr0)]"
 s3="/$(tput setaf 3)!$(tput sgr0)\\"
 
-# Detectar idioma
-function lang(){
-    if [ "$(echo "$LANG" | head -c 2)" == "es" ]; then
-        ### SPANISH ###
-        # HELP
-        help="$(tput setaf 2)  _        _ $(tput sgr0) _              _\n$(tput setaf 2) | |      | |$(tput sgr0)| |            | |\n$(tput setaf 2) | |______| |$(tput sgr0)| |____________| |        Version: 1.0\n$(tput setaf 2) |  ______  |$(tput sgr0)|  ____________  | By Miguelillo & fromCharCode\n$(tput setaf 2) | | Half | |$(tput sgr0)| | Handshaker | |         27/04/2021\n$(tput setaf 2) |_|      |_|$(tput sgr0)|_|            |_|\n\n    -> https://github.com/Miguelillo000/halfhandshaker <-\n\n\n Opciones:\n \n $(tput setaf 2)-h, --help$(tput sgr0)            Muestra esta ayuda\n $(tput setaf 2)-v, --version$(tput sgr0)         Muestra la version del script\n\n \n $(tput setaf 2)-i, --interface            $(tput setaf 3)<interfaz>$(tput sgr0)   Especifica la interfaz a usar\n\n $(tput setaf 2)-e, --essid    $(tput setaf 3)<nombre>$(tput sgr0)         Especifica el nombre del AP falso\n $(tput setaf 2)-o, --output   $(tput setaf 3)<nombre>$(tput sgr0)         Elige el nombre del archivo .cap y hccapx\n \n $(tput setaf 2)-n, --no-auto-stop$(tput sgr0)     No para automaticamente cuando se detecta un handshake\n $(tput setaf 2)-r, --random-mac$(tput sgr0)       Cambia la mac de la tarjeta de red por una al azar\n \n\n Ejemplos:\n\n ./halfhandshaker.sh -i wlan0 -e \"Bar-Juanito\" -o \"red-bar\"\n \n ./halfhandshaker.sh -i wlan0 -e \"Oficinas-12\" -r\n \n ./halfhandshaker.sh -i wlan0 -e \"Red-profesores\" -r -o \"wifi-profes\"\n"
-		root_required="Es necesario ejecutar el script con permisos de administrador"; needs="Falta dependencia:"; valid_essid="Se necesita especificar una essid valida"; valid_interface="Se necesita especificar una interfaz valida"; changing_mac="Cambiando mac ->"; changing_mac_o="Restaurando mac ->"; starting="Iniciando"; ctrl_c="para parar"; file_is="Handshake guardado en"; argumment_in="Argumento invalido"; exists1="El archivo"; exists2="ya existe"; overwrite="¿Quieres sobreescribirlo?"; exiting="Saliendo..."; option_in="Opcion invalida"; saving_err="Error al guardar"
-    else
-
-        ### ENGLISH ###
-
-        # HELP
-
-        help="$(tput setaf 2)  _        _ $(tput sgr0) _              _ \n$(tput setaf 2) | |      | |$(tput sgr0)| |            | |\n$(tput setaf 2) | |______| |$(tput sgr0)| |____________| |         Beta 0.5\n$(tput setaf 2) |  ______  |$(tput sgr0)|  ____________  | By Miguelillo & fromCharCode\n$(tput setaf 2) | | Half | |$(tput sgr0)| | Handshaker | |        28/06/2020\n$(tput setaf 2) |_|      |_|$(tput sgr0)|_|            |_|\n \n    -> https://github.com/Miguelillo000/halfhandshaker <-\n\n \n Options:\n \n $(tput setaf 2)-h, --help$(tput sgr0)            Show help\n $(tput setaf 2)-v, --version$(tput sgr0)         Show script version\n \n \n $(tput setaf 2)-i, --interface            $(tput setaf 3)<interface>$(tput sgr0)   Set the network interface\n \n $(tput setaf 2)-e, --essid    $(tput setaf 3)<name>$(tput sgr0)         Set the fake AP's name\n $(tput setaf 2)-o, --output   $(tput setaf 3)<name>$(tput sgr0)         Set the name of the cap and hccapx files\n \n $(tput setaf 2)-n, --no-auto-stop$(tput sgr0)     Does not stop automatically when a handshake is captured\n $(tput setaf 2)-r, --random-mac$(tput sgr0)       Change the mac address of the interface by a random one\n \n \n Ejemplos:\n\n ./halfhandshaker.sh -i wlan0 -e \"John-pub\" -o \"pub-net\"\n \n ./halfhandshaker.sh -i wlan0 -e \"Offices-12\" -r\n \n ./halfhandshaker.sh -i wlan0 -e \"SchoolNet\" -r -o \"teachers-wifi\"\n    "
-    	root_required="Root priveleges are necessary"; needs="Missing dependency "; valid_essid="A valid essid is required"; valid_interface="A valid interface is required"; changing_mac="Changing mac ->"; changing_mac_o="Restoring mac ->"; starting="Starting"; ctrl_c="to stop"; file_is="Handshake saved in"; argumment_in="Invalid argumment"; exists1="File"; exists2="already exists"; overwrite="Overwrite it?"; exiting="Exitting..."; option_in="Invalid option"; saving_err="Error at saving"
-    fi
-
-}
-lang
-
 # Ayuda
 function show_help(){
 	echo -e "$help"
@@ -56,34 +36,11 @@ printout() {
     exit_script
 }
 
-# Comprobacion de permisos de administrador y las dependencias
-function check(){
-	# Comprueba si tiene permisos de adminsitrador
-	if [[ "$(id -u)" != "0" ]]; then
-		echo; echo " $s3 $root_required"; echo
-		exit 0
-	fi
-	
-	# Comprobando las herramientas
-	no_tool=0
-	dep_list="tcpdump hostapd ip macchanger xterm python3"
-	for dependency in $dep_list; do
-		if [ -z "$(command -v $dependency)" ]; then 
-			echo " $s3 $needs $dependency"
-	   		no_tool=1
-   		fi
-	done
-	if [ "$no_tool" == "1" ]; then
-		exit_script
-	fi
-}
-check
-
 # Comprobar essid
 function check_essid(){
 	if [ -z "$essid" ]; then
 		echo " $s3 $valid_essid"
-		exit 0
+		exit 1
 	fi
 }
 
@@ -98,7 +55,7 @@ function check_interface() {
 	fi
 	if [ "$error" == "1" ]; then
 		echo " $s3 $valid_interface"
-		exit 0  
+		exit 1  
 	fi
 }
 
@@ -200,10 +157,30 @@ function attack(){
 	exit_script
 }
 
-# Escaneo
-function scan_probes(){
-    check_interface
-}
+# Detectar idioma
+if [ "$(echo "$LANG" | head -c 2)" == "es" ]; then
+	### SPANISH ###
+	# HELP
+	help="$(tput setaf 2)  _        _ $(tput sgr0) _              _\n$(tput setaf 2) | |      | |$(tput sgr0)| |            | |\n$(tput setaf 2) | |______| |$(tput sgr0)| |____________| |        Version: 1.0\n$(tput setaf 2) |  ______  |$(tput sgr0)|  ____________  | By Miguelillo & fromCharCode\n$(tput setaf 2) | | Half | |$(tput sgr0)| | Handshaker | |         27/04/2021\n$(tput setaf 2) |_|      |_|$(tput sgr0)|_|            |_|\n\n    -> https://github.com/Miguelillo000/halfhandshaker <-\n\n\n Opciones:\n \n $(tput setaf 2)-h, --help$(tput sgr0)            Muestra esta ayuda\n $(tput setaf 2)-v, --version$(tput sgr0)         Muestra la version del script\n\n \n $(tput setaf 2)-i, --interface            $(tput setaf 3)<interfaz>$(tput sgr0)   Especifica la interfaz a usar\n\n $(tput setaf 2)-e, --essid    $(tput setaf 3)<nombre>$(tput sgr0)         Especifica el nombre del AP falso\n $(tput setaf 2)-o, --output   $(tput setaf 3)<nombre>$(tput sgr0)         Elige el nombre del archivo .cap y hccapx\n \n $(tput setaf 2)-n, --no-auto-stop$(tput sgr0)     No para automaticamente cuando se detecta un handshake\n $(tput setaf 2)-r, --random-mac$(tput sgr0)       Cambia la mac de la tarjeta de red por una al azar\n \n\n Ejemplos:\n\n ./halfhandshaker.sh -i wlan0 -e \"Bar-Juanito\" -o \"red-bar\"\n \n ./halfhandshaker.sh -i wlan0 -e \"Oficinas-12\" -r\n \n ./halfhandshaker.sh -i wlan0 -e \"Red-profesores\" -r -o \"wifi-profes\"\n"
+	root_required="Es necesario ejecutar el script con permisos de administrador"; needs="Falta dependencia:"; valid_essid="Se necesita especificar una essid valida"; valid_interface="Se necesita especificar una interfaz valida"; changing_mac="Cambiando mac ->"; changing_mac_o="Restaurando mac ->"; starting="Iniciando"; ctrl_c="para parar"; file_is="Handshake guardado en"; argumment_in="Argumento invalido"; exists1="El archivo"; exists2="ya existe"; overwrite="¿Quieres sobreescribirlo?"; exiting="Saliendo..."; option_in="Opcion invalida"; saving_err="Error al guardar"
+else
+	### ENGLISH ###
+	# HELP
+	help="$(tput setaf 2)  _        _ $(tput sgr0) _              _ \n$(tput setaf 2) | |      | |$(tput sgr0)| |            | |\n$(tput setaf 2) | |______| |$(tput sgr0)| |____________| |         Beta 0.5\n$(tput setaf 2) |  ______  |$(tput sgr0)|  ____________  | By Miguelillo & fromCharCode\n$(tput setaf 2) | | Half | |$(tput sgr0)| | Handshaker | |        28/06/2020\n$(tput setaf 2) |_|      |_|$(tput sgr0)|_|            |_|\n \n    -> https://github.com/Miguelillo000/halfhandshaker <-\n\n \n Options:\n \n $(tput setaf 2)-h, --help$(tput sgr0)            Show help\n $(tput setaf 2)-v, --version$(tput sgr0)         Show script version\n \n \n $(tput setaf 2)-i, --interface            $(tput setaf 3)<interface>$(tput sgr0)   Set the network interface\n \n $(tput setaf 2)-e, --essid    $(tput setaf 3)<name>$(tput sgr0)         Set the fake AP's name\n $(tput setaf 2)-o, --output   $(tput setaf 3)<name>$(tput sgr0)         Set the name of the cap and hccapx files\n \n $(tput setaf 2)-n, --no-auto-stop$(tput sgr0)     Does not stop automatically when a handshake is captured\n $(tput setaf 2)-r, --random-mac$(tput sgr0)       Change the mac address of the interface by a random one\n \n \n Ejemplos:\n\n ./halfhandshaker.sh -i wlan0 -e \"John-pub\" -o \"pub-net\"\n \n ./halfhandshaker.sh -i wlan0 -e \"Offices-12\" -r\n \n ./halfhandshaker.sh -i wlan0 -e \"SchoolNet\" -r -o \"teachers-wifi\"\n    "
+	root_required="Root priveleges are necessary"; needs="Missing dependency "; valid_essid="A valid essid is required"; valid_interface="A valid interface is required"; changing_mac="Changing mac ->"; changing_mac_o="Restoring mac ->"; starting="Starting"; ctrl_c="to stop"; file_is="Handshake saved in"; argumment_in="Invalid argumment"; exists1="File"; exists2="already exists"; overwrite="Overwrite it?"; exiting="Exitting..."; option_in="Invalid option"; saving_err="Error at saving"
+fi
+
+# Comprobando privilegios
+id -u | grep -q "^0$" || { echo -e  "\n $s3 $root_required \n"; exit 1; }
+
+# Comprobando las herramientas
+for dependency in hostapd ip macchanger xterm python3 tcpdump; do
+	if [ -z "$(command -v $dependency)" ]; then 
+		echo -e "\n $s3 $needs $dependency"
+   		no_tool=1
+	fi
+done
+[[ -v no_tool ]] && { echo; exit 1; }
 
 # Comprobando si está vacio
 if [ $# == "0" ]; then


### PR DESCRIPTION
- Error in "check" function fixed by exiting the script instead of calling exit_script function.
- Code optimization in "check" function replacing if conditionals by some one line solution, removal of unnecessaries variables. 
- Exit 0 changed to exit 1 when pointing out to errors. 
- Functions immediately called once after their declarations (check and lang) are removed and their code is placed after variables and functions declaration for consistency.
- Function "escaneo" deleted as it was never called